### PR TITLE
Small Quality of Life Improvements

### DIFF
--- a/lunadon/public/alt/xp.css
+++ b/lunadon/public/alt/xp.css
@@ -1364,7 +1364,7 @@ a.status-card .status-card__content * {
 
 @media screen and (max-width: 600px) {
   .window, .windowContainer {
-    max-width: 90vw;
+    max-width: 90vw !important;
   }
 
   .windowContainer {

--- a/lunadon/public/alt/xp.css
+++ b/lunadon/public/alt/xp.css
@@ -27,6 +27,7 @@ html {
 body {
   background-image: url("/alt/bliss.jpeg") !important;
   background-attachment: fixed !important;
+  background-size: cover;
 }
 
 a,

--- a/lunadon/public/alt/xp.css
+++ b/lunadon/public/alt/xp.css
@@ -1362,10 +1362,20 @@ a.status-card .status-card__content * {
 }
 
 @media screen and (max-width: 600px) {
-  .window,
-  .windowBody {
-    max-width: 90vw !important;
+  .window, .windowContainer {
+    max-width: 90vw;
   }
+
+  .windowContainer {
+    margin-right: auto;
+    margin-left: auto;
+  }
+
+  #headerLogoAlt, #headerLogo {
+    max-width: min(100%, 350px) !important;
+    box-sizing: border-box;
+  }
+
 }
 
 /* Icons */

--- a/lunadon/public/alt/xp.css
+++ b/lunadon/public/alt/xp.css
@@ -1370,6 +1370,7 @@ a.status-card .status-card__content * {
   .windowContainer {
     margin-right: auto;
     margin-left: auto;
+    margin-bottom: 5px;
   }
 
   #headerLogoAlt, #headerLogo {


### PR DESCRIPTION
Hi there, 

Love your patch! I've made some small fixes, mostly regarding the Mobile UI. 

Firstly, I fixed the windows and the logo sizing:

![grafik](https://user-images.githubusercontent.com/92150718/160261455-3d122b99-00c9-48ac-b2fe-74ddf93befc6.png)

This also applies to the other pages as well. /about is just a good example. :)
Another 'freebie' we get with this is that the /about no longer x-overflows because the logo is now no longer overflowing. 

<hr>

I also 'fixed' the background image (I don't know if you did this on purpose). Previously, the background image was repeating because it is quite low-res:
![grafik](https://user-images.githubusercontent.com/92150718/160261783-17d3c133-abc4-4f59-a83e-aa2e9667a54c.png)


My 'fix' makes the background image cover the whole background:
![grafik](https://user-images.githubusercontent.com/92150718/160261599-982ae17a-e4e6-4792-91a3-4c06991ba2ef.png)

This 'fix' has one drawback though: Since the image gets scaled when the screen is too high-res it'll get pixelated. 


This isn't much, but makes mastodon with this patch look a bit more polished.

Cheers,
Finn